### PR TITLE
Fix false negative as reported in self log when clean payload is called

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchLogClient.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchLogClient.cs
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.Elasticsearch.Durable
                     var invalidPayload = GetInvalidPayloadAsync(response, payload, out cleanPayload);
                     if ((cleanPayload?.Any() ?? false) && first)
                     {
-                        await SendPayloadAsync(cleanPayload, false);
+                        return await SendPayloadAsync(cleanPayload, false);
                     }
 
                     return new SentPayloadResult(response, true, invalidPayload);
@@ -100,13 +100,17 @@ namespace Serilog.Sinks.Elasticsearch.Durable
 
                 if (int.TryParse(id.Split('_')[0], out int index))
                 {
-                    SelfLog.WriteLine("Received failed ElasticSearch shipping result {0}: {1}. Failed payload : {2}.", status, errorString, payload.ElementAt(index * 2 + 1));
                     badPayload.Add(payload.ElementAt(index * 2));
                     badPayload.Add(payload.ElementAt(index * 2 + 1));
                     if (_cleanPayload != null)
                     {
+                        SelfLog.WriteLine("Received failed ElasticSearch shipping result, calling clean payload {0}: {1}", status, errorString);
                         cleanPayload.Add(payload.ElementAt(index * 2));
                         cleanPayload.Add(_cleanPayload(payload.ElementAt(index * 2 + 1), status, errorString));
+                    }
+                    else
+                    {
+                        SelfLog.WriteLine("Received failed ElasticSearch shipping result {0}: {1}. Failed payload : {2}.", status, errorString, payload.ElementAt(index * 2 + 1));
                     }
                 }
                 else

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchLogClient.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchLogClient.cs
@@ -98,24 +98,16 @@ namespace Serilog.Sinks.Elasticsearch.Durable
                 var error = itemIndex?["error"];
                 var errorString = $"type: {error?["type"] ?? "Unknown"}, reason: {error?["reason"] ?? "Unknown"}";
 
+                SelfLog.WriteLine($"Received failed ElasticSearch shipping result {status}: {errorString}.");
                 if (int.TryParse(id.Split('_')[0], out int index))
                 {
                     badPayload.Add(payload.ElementAt(index * 2));
                     badPayload.Add(payload.ElementAt(index * 2 + 1));
                     if (_cleanPayload != null)
                     {
-                        SelfLog.WriteLine("Received failed ElasticSearch shipping result, calling clean payload {0}: {1}", status, errorString);
                         cleanPayload.Add(payload.ElementAt(index * 2));
                         cleanPayload.Add(_cleanPayload(payload.ElementAt(index * 2 + 1), status, errorString));
                     }
-                    else
-                    {
-                        SelfLog.WriteLine("Received failed ElasticSearch shipping result {0}: {1}. Failed payload : {2}.", status, errorString, payload.ElementAt(index * 2 + 1));
-                    }
-                }
-                else
-                {
-                    SelfLog.WriteLine($"Received failed ElasticSearch shipping result {status}: {errorString}.");
                 }
             }
 


### PR DESCRIPTION
**What issue does this PR address?**
When BufferCleanPayload callback is called the selflog is still written to with the error even though it may have been fixed after cleaning. Also contains strange self log that says 'HTTP shipping failed with 200'

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
