### PR TITLE
fix: correctly reading bufferRetainedInvalidPayloads from appsettings

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
@@ -12,19 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Serilog.Sinks.Elasticsearch;
+using Serilog.Sinks.Elasticsearch.Durable;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using Serilog.Configuration;
-using Serilog.Core;
-using Serilog.Events;
-using Serilog.Sinks.Elasticsearch;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using Elasticsearch.Net;
-using Serilog.Formatting;
-using Serilog.Sinks.Elasticsearch.Durable;
+using System.IO;
+using System.Linq;
 
 namespace Serilog
 {
@@ -143,6 +138,7 @@ namespace Serilog
         /// <param name="failureSink">Sink to use when Elasticsearch is unable to accept the events. This is optionally and depends on the EmitEventFailure setting.</param>   
         /// <param name="singleEventSizePostingLimit"><see cref="ElasticsearchSinkOptions.SingleEventSizePostingLimit"/>The maximum length of an event allowed to be posted to Elasticsearch.default null</param>
         /// <param name="templateCustomSettings">Add custom elasticsearch settings to the template</param>
+        /// <param name="bufferRetainedInvalidPayloadsLimitBytes"><see cref="ElasticsearchSinkOptions.BufferRetainedInvalidPayloadsLimitBytes"/></param>
         /// <param name="batchAction">Configures the OpType being used when inserting document in batch. Must be set to create for data streams.</param>
         /// <returns>LoggerConfiguration object</returns>
         /// <exception cref="ArgumentNullException"><paramref name="nodeUris"/> is <see langword="null" />.</exception>
@@ -181,7 +177,8 @@ namespace Serilog
             ILogEventSink failureSink = null,
             long? singleEventSizePostingLimit = null,
             int? bufferFileCountLimit = null,
-            Dictionary<string,string> templateCustomSettings = null,
+            Dictionary<string, string> templateCustomSettings = null,
+            long? bufferRetainedInvalidPayloadsLimitBytes = null,
             ElasticOpType batchAction = ElasticOpType.Index)
         {
             if (string.IsNullOrEmpty(nodeUris))
@@ -274,6 +271,8 @@ namespace Serilog
             options.Serializer = serializer;
 
             options.TemplateCustomSettings = templateCustomSettings;
+
+            options.BufferRetainedInvalidPayloadsLimitBytes = bufferRetainedInvalidPayloadsLimitBytes;
 
             return Elasticsearch(loggerSinkConfiguration, options);
         }


### PR DESCRIPTION
**What issue does this PR address?**
`bufferRetainedInvalidPayloadsLimitBytes` is not read from appsettings

**Does this PR introduce a breaking change?**
No, I hope not

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
I have not created an issue for this as it is only a small change. If you'd like me to do so before the merge I can do it.

I discovered this when trying to figure out why `invalid-guid` files were not being removed from my log folder. 