### PR TITLE
Fix internal or IntelliSense typos

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
@@ -70,7 +70,7 @@ namespace Serilog
         /// Overload to allow basic configuration through AppSettings.
         /// </summary>
         /// <param name="loggerSinkConfiguration">Options for the sink.</param>
-        /// <param name="nodeUris">A comma or semi column separated list of URIs for Elasticsearch nodes.</param>
+        /// <param name="nodeUris">A comma or semi-colon separated list of URIs for Elasticsearch nodes.</param>
         /// <param name="indexFormat"><see cref="ElasticsearchSinkOptions.IndexFormat"/></param>
         /// <param name="templateName"><see cref="ElasticsearchSinkOptions.TemplateName"/></param>
         /// <param name="typeName"><see cref="ElasticsearchSinkOptions.TypeName"/></param>
@@ -82,7 +82,7 @@ namespace Serilog
         /// <param name="bufferBaseFilename"><see cref="ElasticsearchSinkOptions.BufferBaseFilename"/></param>
         /// <param name="bufferFileSizeLimitBytes"><see cref="ElasticsearchSinkOptions.BufferFileSizeLimitBytes"/></param>
         /// <param name="bufferLogShippingInterval"><see cref="ElasticsearchSinkOptions.BufferLogShippingInterval"/></param>
-        /// <param name="connectionGlobalHeaders">A comma or semi column separated list of key value pairs of headers to be added to each elastic http request</param>
+        /// <param name="connectionGlobalHeaders">A comma or semi-colon separated list of key value pairs of headers to be added to each elastic http request</param>
         [Obsolete("New code should not be compiled against this obsolete overload"), EditorBrowsable(EditorBrowsableState.Never)]
         public static LoggerConfiguration Elasticsearch(
            this LoggerSinkConfiguration loggerSinkConfiguration,
@@ -109,7 +109,7 @@ namespace Serilog
         /// Overload to allow basic configuration through AppSettings.
         /// </summary>
         /// <param name="loggerSinkConfiguration">Options for the sink.</param>
-        /// <param name="nodeUris">A comma or semi column separated list of URIs for Elasticsearch nodes.</param>
+        /// <param name="nodeUris">A comma or semi-colon separated list of URIs for Elasticsearch nodes.</param>
         /// <param name="indexFormat"><see cref="ElasticsearchSinkOptions.IndexFormat"/></param>
         /// <param name="templateName"><see cref="ElasticsearchSinkOptions.TemplateName"/></param>
         /// <param name="typeName"><see cref="ElasticsearchSinkOptions.TypeName"/></param>
@@ -122,7 +122,7 @@ namespace Serilog
         /// <param name="bufferFileSizeLimitBytes"><see cref="ElasticsearchSinkOptions.BufferFileSizeLimitBytes"/></param>
         /// <param name="bufferFileCountLimit"><see cref="ElasticsearchSinkOptions.BufferFileCountLimit"/></param>        
         /// <param name="bufferLogShippingInterval"><see cref="ElasticsearchSinkOptions.BufferLogShippingInterval"/></param>
-        /// <param name="connectionGlobalHeaders">A comma or semi column separated list of key value pairs of headers to be added to each elastic http request</param>   
+        /// <param name="connectionGlobalHeaders">A comma or semi-colon separated list of key value pairs of headers to be added to each elastic http request</param>
         /// <param name="connectionTimeout"><see cref="ElasticsearchSinkOptions.ConnectionTimeout"/>The connection timeout (in seconds) when sending bulk operations to elasticsearch (defaults to 5).</param>   
         /// <param name="emitEventFailure"><see cref="ElasticsearchSinkOptions.EmitEventFailure"/>Specifies how failing emits should be handled.</param>  
         /// <param name="queueSizeLimit"><see cref="ElasticsearchSinkOptions.QueueSizeLimit"/>The maximum number of events that will be held in-memory while waiting to ship them to Elasticsearch. Beyond this limit, events will be dropped. The default is 100,000. Has no effect on durable log shipping.</param>   

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchSink.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchSink.cs
@@ -82,7 +82,7 @@ namespace Serilog.Sinks.Elasticsearch
             if (events == null || !events.Any())
                 return Task.FromResult<T>(default(T));
 
-            var payload = CreatePlayLoad(events);
+            var payload = CreatePayload(events);
             return _state.Client.BulkAsync<T>(PostData.MultiJson(payload));
         }
 
@@ -97,7 +97,7 @@ namespace Serilog.Sinks.Elasticsearch
             if (events == null || !events.Any())
                 return null;
 
-            var payload = CreatePlayLoad(events);
+            var payload = CreatePayload(events);
             return _state.Client.Bulk<T>(PostData.MultiJson(payload));
         }
 
@@ -111,7 +111,7 @@ namespace Serilog.Sinks.Elasticsearch
             if (_state.Options.EmitEventFailure.HasFlag(EmitEventFailureHandling.WriteToSelfLog))
             {
                 // ES reports an error, output the error to the selflog
-                SelfLog.WriteLine("Caught exception while preforming bulk operation to Elasticsearch: {0}", ex);
+                SelfLog.WriteLine("Caught exception while performing bulk operation to Elasticsearch: {0}", ex);
             }
             if (_state.Options.EmitEventFailure.HasFlag(EmitEventFailureHandling.WriteToFailureSink) &&
                 _state.Options.FailureSink != null)
@@ -165,7 +165,7 @@ namespace Serilog.Sinks.Elasticsearch
             return settings.GetType().GetProperty(name) != null;
         }
 
-        private IEnumerable<string> CreatePlayLoad(IEnumerable<LogEvent> events)
+        private IEnumerable<string> CreatePayload(IEnumerable<LogEvent> events)
         {
             if (!_state.TemplateRegistrationSuccess && _state.Options.RegisterTemplateFailure == RegisterTemplateRecovery.FailSink)
             {


### PR DESCRIPTION
**What issue does this PR address?**
Cleaning up a few very minor typos in internal methods or exposed via
IntelliSense:

 * "semi column" -> "semi-colon"
 * "preforming" -> "performing"
 * "CreatePlayLoad" -> "CreatePayload"

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
