### PR TITLE
Add `ElasticsearchSinkOptions.BufferFileRollingInterval` option

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -55,4 +55,10 @@
         <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
     </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Serilog.Sinks.Elasticsearch.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c6fe0fe83ef33c1080bf30690765bc6eb0df26ebfdf8f21670c64265b30db09f73a0dea5b3db4c9d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b81894191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066b19485ec</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/DurableElasticsearchSink.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/DurableElasticsearchSink.cs
@@ -39,7 +39,6 @@ namespace Serilog.Sinks.Elasticsearch.Durable
                 throw new ArgumentException("Cannot create the durable ElasticSearch sink without a buffer base file name!");
             }
 
-            
             _sink = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
                 .WriteTo.File(_state.DurableFormatter,
@@ -62,7 +61,8 @@ namespace Serilog.Sinks.Elasticsearch.Durable
                  typeName:_state.Options.TypeName, 
                  serialize:_state.Serialize,  
                  getIndexForEvent: _state.GetBufferedIndexForEvent,
-                 elasticOpType: _state.Options.BatchAction);
+                 elasticOpType: _state.Options.BatchAction,
+                 rollingInterval: options.BufferFileRollingInterval);
 
             _shipper = new ElasticsearchLogShipper(
                 bufferBaseFilename: _state.Options.BufferBaseFilename,
@@ -74,7 +74,8 @@ namespace Serilog.Sinks.Elasticsearch.Durable
                 payloadReader: payloadReader,
                 retainedInvalidPayloadsLimitBytes: _state.Options.BufferRetainedInvalidPayloadsLimitBytes,
                 bufferSizeLimitBytes: _state.Options.BufferFileSizeLimitBytes,
-                registerTemplateIfNeeded: _state.RegisterTemplateIfNeeded);
+                registerTemplateIfNeeded: _state.RegisterTemplateIfNeeded,
+                rollingInterval: options.BufferFileRollingInterval);
                 
         }
 

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/DurableElasticsearchSink.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/DurableElasticsearchSink.cs
@@ -44,14 +44,13 @@ namespace Serilog.Sinks.Elasticsearch.Durable
                 .MinimumLevel.Verbose()
                 .WriteTo.File(_state.DurableFormatter,
                     options.BufferBaseFilename + FileNameSuffix,
-                    rollingInterval: RollingInterval.Day,
+                    rollingInterval: options.BufferFileRollingInterval,
                     fileSizeLimitBytes: options.BufferFileSizeLimitBytes,
                     rollOnFileSizeLimit: true,
                     retainedFileCountLimit: options.BufferFileCountLimit,
                     levelSwitch: _state.Options.LevelSwitch,
                     encoding: Encoding.UTF8)
                 .CreateLogger();
-
             
             var elasticSearchLogClient = new ElasticsearchLogClient(
                 elasticLowLevelClient: _state.Client, 

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchLogShipper.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchLogShipper.cs
@@ -30,12 +30,13 @@ namespace Serilog.Sinks.Elasticsearch.Durable
         /// <param name="retainedInvalidPayloadsLimitBytes"></param>
         /// <param name="bufferSizeLimitBytes"></param>
         /// <param name="registerTemplateIfNeeded"></param>
+        /// <param name="rollingInterval"></param>
         public ElasticsearchLogShipper(string bufferBaseFilename, int batchPostingLimit, TimeSpan period,
             long? eventBodyLimitBytes, LoggingLevelSwitch levelControlSwitch, ILogClient<List<string>> logClient,
             IPayloadReader<List<string>> payloadReader, long? retainedInvalidPayloadsLimitBytes,
-            long? bufferSizeLimitBytes, Action registerTemplateIfNeeded)
-            : base(bufferBaseFilename, batchPostingLimit, period, eventBodyLimitBytes,
-            levelControlSwitch, logClient, payloadReader, retainedInvalidPayloadsLimitBytes, bufferSizeLimitBytes)
+            long? bufferSizeLimitBytes, Action registerTemplateIfNeeded, RollingInterval rollingInterval)
+            : base(bufferBaseFilename, batchPostingLimit, period, eventBodyLimitBytes, levelControlSwitch, logClient, 
+                payloadReader, retainedInvalidPayloadsLimitBytes, bufferSizeLimitBytes, rollingInterval)
         {
             _registerTemplateIfNeeded = registerTemplateIfNeeded;                        
         }

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchPayloadReader.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchPayloadReader.cs
@@ -17,6 +17,7 @@ namespace Serilog.Sinks.Elasticsearch.Durable
         private readonly Func<object, string> _serialize;
         private readonly Func<string, DateTime,string> _getIndexForEvent;
         private readonly ElasticOpType _elasticOpType;
+        private readonly RollingInterval _rollingInterval;
         private List<string> _payload;
         private int _count;
         private DateTime _date;
@@ -29,14 +30,21 @@ namespace Serilog.Sinks.Elasticsearch.Durable
         /// <param name="serialize"></param>
         /// <param name="getIndexForEvent"></param>
         /// <param name="elasticOpType"></param>
+        /// <param name="rollingInterval"></param>
         public ElasticsearchPayloadReader(string pipelineName, string typeName, Func<object, string> serialize,
-            Func<string, DateTime, string> getIndexForEvent, ElasticOpType elasticOpType)
+            Func<string, DateTime, string> getIndexForEvent, ElasticOpType elasticOpType, RollingInterval rollingInterval)
         {
+            if ((int)rollingInterval < (int)RollingInterval.Day)
+            {
+                throw new ArgumentException("Rolling intervals less frequent than RollingInterval.Day are not supported");
+            }
+            
             _pipelineName = pipelineName;
             _typeName = typeName;
             _serialize = serialize;
             _getIndexForEvent = getIndexForEvent;
             _elasticOpType = elasticOpType;
+            _rollingInterval = rollingInterval;
         }
 
         /// <summary>
@@ -64,8 +72,9 @@ namespace Serilog.Sinks.Elasticsearch.Durable
                 throw new FormatException(string.Format("The file name '{0}' does not seem to follow the right file pattern - it must be named [whatever]-{{Date}}[_n].json", Path.GetFileName(filename)));
             }
 
-            var dateString = lastToken.Substring(0, 8);
-            _date = DateTime.ParseExact(dateString, "yyyyMMdd", CultureInfo.InvariantCulture);            
+            var dateFormat = _rollingInterval.GetFormat();
+            var dateString = lastToken.Substring(0, dateFormat.Length);
+            _date = DateTime.ParseExact(dateString, dateFormat, CultureInfo.InvariantCulture);            
         }
        /// <summary>
        /// 

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchPayloadReader.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchPayloadReader.cs
@@ -74,7 +74,7 @@ namespace Serilog.Sinks.Elasticsearch.Durable
 
             var dateFormat = _rollingInterval.GetFormat();
             var dateString = lastToken.Substring(0, dateFormat.Length);
-            _date = DateTime.ParseExact(dateString, dateFormat, CultureInfo.InvariantCulture);            
+            _date = DateTime.ParseExact(dateString, dateFormat, CultureInfo.InvariantCulture);
         }
        /// <summary>
        /// 

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/RollingIntervalExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/RollingIntervalExtensions.cs
@@ -30,5 +30,26 @@ namespace Serilog.Sinks.Elasticsearch.Durable
                     throw new ArgumentException("Invalid rolling interval");
             }
         }
+
+        public static string GetMatchingDateRegularExpressionPart(this RollingInterval interval)
+        {
+            switch (interval)
+            {
+                case RollingInterval.Infinite:
+                    return "";
+                case RollingInterval.Year:
+                    return "\\d{4}";
+                case RollingInterval.Month:
+                    return "\\d{6}";
+                case RollingInterval.Day:
+                    return "\\d{8}";
+                case RollingInterval.Hour:
+                    return "\\d{10}";
+                case RollingInterval.Minute:
+                    return "\\d{12}";
+                default:
+                    throw new ArgumentException("Invalid rolling interval");
+            }
+        }
     }
 }

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/RollingIntervalExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/RollingIntervalExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+[assembly:
+    InternalsVisibleTo(
+        "Serilog.Sinks.Elasticsearch.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c6fe0fe83ef33c1080bf30690765bc6eb0df26ebfdf8f21670c64265b30db09f73a0dea5b3db4c9d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b81894191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066b19485ec")]
+
+namespace Serilog.Sinks.Elasticsearch.Durable
+{
+    internal static class RollingIntervalExtensions
+    {
+        // From https://github.com/serilog/serilog-sinks-file/blob/dev/src/Serilog.Sinks.File/Sinks/File/RollingIntervalExtensions.cs#L19
+        public static string GetFormat(this RollingInterval interval)
+        {
+            switch (interval)
+            {
+                case RollingInterval.Infinite:
+                    return "";
+                case RollingInterval.Year:
+                    return "yyyy";
+                case RollingInterval.Month:
+                    return "yyyyMM";
+                case RollingInterval.Day:
+                    return "yyyyMMdd";
+                case RollingInterval.Hour:
+                    return "yyyyMMddHH";
+                case RollingInterval.Minute:
+                    return "yyyyMMddHHmm";
+                default:
+                    throw new ArgumentException("Invalid rolling interval");
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/FileSet.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/FileSet.cs
@@ -39,14 +39,16 @@ namespace Serilog.Sinks.Elasticsearch.Durable
 
         const string InvalidPayloadFilePrefix = "invalid-";
 
-        public FileSet(string bufferBaseFilename)
+        public FileSet(string bufferBaseFilename, RollingInterval rollingInterval)
         {
             if (bufferBaseFilename == null) throw new ArgumentNullException(nameof(bufferBaseFilename));
 
             _bookmarkFilename = Path.GetFullPath(bufferBaseFilename + ".bookmark");
             _logFolder = Path.GetDirectoryName(_bookmarkFilename);
             _candidateSearchPath = Path.GetFileName(bufferBaseFilename) + "-*.json";
-            _filenameMatcher = new Regex("^" + Regex.Escape(Path.GetFileName(bufferBaseFilename)) + "-(?<date>\\d{8})(?<sequence>_[0-9]{3,}){0,1}\\.json$");
+            var dateRegularExpressionPart = rollingInterval.GetMatchingDateRegularExpressionPart();
+            _filenameMatcher = new Regex("^" + Regex.Escape(Path.GetFileName(bufferBaseFilename)) + "-(?<date>" 
+                                         + dateRegularExpressionPart + ")(?<sequence>_[0-9]{3,}){0,1}\\.json$");
         }
 
         public BookmarkFile OpenBookmarkFile()

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/FileSet.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/FileSet.cs
@@ -19,9 +19,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Serilog.Debugging;
-
+[assembly:
+    InternalsVisibleTo(
+        "Serilog.Sinks.Elasticsearch.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c6fe0fe83ef33c1080bf30690765bc6eb0df26ebfdf8f21670c64265b30db09f73a0dea5b3db4c9d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b81894191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066b19485ec")]
 namespace Serilog.Sinks.Elasticsearch.Durable
 {
     /// <summary>
@@ -43,7 +46,7 @@ namespace Serilog.Sinks.Elasticsearch.Durable
             _bookmarkFilename = Path.GetFullPath(bufferBaseFilename + ".bookmark");
             _logFolder = Path.GetDirectoryName(_bookmarkFilename);
             _candidateSearchPath = Path.GetFileName(bufferBaseFilename) + "-*.json";
-            _filenameMatcher = new Regex("^" + Regex.Escape(Path.GetFileName(bufferBaseFilename)) + "-(?<date>\\d{0,12})(?<sequence>_[0-9]{3,}){0,1}\\.json$");
+            _filenameMatcher = new Regex("^" + Regex.Escape(Path.GetFileName(bufferBaseFilename)) + "-(?<date>\\d{8})(?<sequence>_[0-9]{3,}){0,1}\\.json$");
         }
 
         public BookmarkFile OpenBookmarkFile()

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/FileSet.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/FileSet.cs
@@ -43,7 +43,7 @@ namespace Serilog.Sinks.Elasticsearch.Durable
             _bookmarkFilename = Path.GetFullPath(bufferBaseFilename + ".bookmark");
             _logFolder = Path.GetDirectoryName(_bookmarkFilename);
             _candidateSearchPath = Path.GetFileName(bufferBaseFilename) + "-*.json";
-            _filenameMatcher = new Regex("^" + Regex.Escape(Path.GetFileName(bufferBaseFilename)) + "-(?<date>\\d{8})(?<sequence>_[0-9]{3,}){0,1}\\.json$");
+            _filenameMatcher = new Regex("^" + Regex.Escape(Path.GetFileName(bufferBaseFilename)) + "-(?<date>\\d{0,12})(?<sequence>_[0-9]{3,}){0,1}\\.json$");
         }
 
         public BookmarkFile OpenBookmarkFile()

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/LogShipper.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/LogShipper.cs
@@ -76,6 +76,7 @@ namespace Serilog.Sinks.Elasticsearch.Durable
         /// <param name="payloadReader"></param>
         /// <param name="retainedInvalidPayloadsLimitBytes"></param>
         /// <param name="bufferSizeLimitBytes"></param>
+        /// <param name="rollingInterval"></param>
         public LogShipper(            
             string bufferBaseFilename,            
             int batchPostingLimit,
@@ -85,7 +86,8 @@ namespace Serilog.Sinks.Elasticsearch.Durable
             ILogClient<TPayload> logClient,
             IPayloadReader<TPayload> payloadReader,
             long? retainedInvalidPayloadsLimitBytes,
-            long? bufferSizeLimitBytes)
+            long? bufferSizeLimitBytes,
+            RollingInterval rollingInterval = RollingInterval.Day)
         {
             _batchPostingLimit = batchPostingLimit;
             _eventBodyLimitBytes = eventBodyLimitBytes;
@@ -95,7 +97,7 @@ namespace Serilog.Sinks.Elasticsearch.Durable
             _connectionSchedule = new ExponentialBackoffConnectionSchedule(period);
             _retainedInvalidPayloadsLimitBytes = retainedInvalidPayloadsLimitBytes;
             _bufferSizeLimitBytes = bufferSizeLimitBytes;
-            _fileSet = new FileSet(bufferBaseFilename);
+            _fileSet = new FileSet(bufferBaseFilename, rollingInterval);
             _timer = new PortableTimer(c => OnTick());
             SetTimer();
 

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -276,6 +276,8 @@ namespace Serilog.Sinks.Elasticsearch
         
         /// <summary>
         /// The interval at which buffer log files will roll over to a new file. The default is <see cref="RollingInterval.Day"/>.
+        /// Less frequent intervals like <see cref="RollingInterval.Infinite"/>, <see cref="RollingInterval.Year"/>,
+        /// <see cref="RollingInterval.Month"/> are not supported.
         /// </summary>
         public RollingInterval BufferFileRollingInterval { get; set; }
 

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -273,6 +273,11 @@ namespace Serilog.Sinks.Elasticsearch
         /// When set to true splits the StackTrace by new line and writes it as a an array of strings.
         /// </summary>
         public bool FormatStackTraceAsArray { get; set; }
+        
+        /// <summary>
+        /// The interval at which buffer log files will roll over to a new file. The default is <see cref="RollingInterval.Day"/>.
+        /// </summary>
+        public RollingInterval BufferFileRollingInterval { get; set; }
 
         /// <summary>
         /// Configures the elasticsearch sink defaults
@@ -294,6 +299,7 @@ namespace Serilog.Sinks.Elasticsearch
             this.BufferFileSizeLimitBytes = 100L * 1024 * 1024;
             this.FormatStackTraceAsArray = false;
             this.ConnectionPool = new SingleNodeConnectionPool(_defaultNode);
+            this.BufferFileRollingInterval = RollingInterval.Day;
         }
 
         /// <summary>

--- a/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchPayloadReaderTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchPayloadReaderTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Serilog.Sinks.Elasticsearch.Durable;
+using Xunit;
+
+namespace Serilog.Sinks.Elasticsearch.Tests;
+
+public class ElasticsearchPayloadReaderTests : IDisposable
+{
+    private readonly string _tempFileFullPathTemplate;
+    private string _bufferFileName;
+
+    public ElasticsearchPayloadReaderTests()
+    {
+        _tempFileFullPathTemplate = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")) + "-{0}.json";
+    }
+
+    public void Dispose()
+    {
+        System.IO.File.Delete(_bufferFileName);
+    }
+
+    [Theory]
+    [InlineData(RollingInterval.Day)]
+    [InlineData(RollingInterval.Hour)]
+    [InlineData(RollingInterval.Infinite)]
+    [InlineData(RollingInterval.Minute)]
+    [InlineData(RollingInterval.Month)]
+    [InlineData(RollingInterval.Year)]
+    public void ElasticsearchPayloadReader_ReadPayload_ShouldReadSpecifiedTypesOfRollingFile(
+        RollingInterval rollingInterval)
+    {
+        // Arrange
+        var format = rollingInterval.GetFormat();
+        var payloadReader = new ElasticsearchPayloadReader("testPipelineName",
+            "TestTypeName",
+            null,
+            (_, _) => "TestIndex",
+            ElasticOpType.Index);
+        var lines = new[]
+        {
+            rollingInterval.ToString()
+        };
+        _bufferFileName = string.Format(_tempFileFullPathTemplate,
+            string.IsNullOrEmpty(format) ? string.Empty : new DateTime(2000, 1, 1).ToString(format));
+        // Important to use UTF8 with BOM if we are starting from 0 position 
+        System.IO.File.WriteAllLines(_bufferFileName, lines, new UTF8Encoding(true));
+
+        // Act
+        var fileSetPosition = new FileSetPosition(0, _bufferFileName);
+        var count = 0;
+        var payload =
+            payloadReader.ReadPayload(int.MaxValue,
+                null,
+                ref fileSetPosition,
+                ref count,
+                _bufferFileName);
+
+        // Assert
+        payload.Count.Should().Be(lines.Length * 2);
+        payload[1].Should().Be(lines[0]);
+    }
+}

--- a/test/Serilog.Sinks.Elasticsearch.Tests/FileSetTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/FileSetTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Serilog.Sinks.Elasticsearch.Durable;
+using Xunit;
+
+namespace Serilog.Sinks.Elasticsearch.Tests;
+
+public class FileSetTests : IDisposable
+{
+    private readonly string _fileNameBase;
+    private readonly string _tempFileFullPathTemplate;
+    private Dictionary<RollingInterval, string> _bufferFileNames;
+
+    public FileSetTests()
+    {
+        _fileNameBase = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        _tempFileFullPathTemplate = _fileNameBase + "-{0}.json";
+    }
+
+    public void Dispose()
+    {
+        foreach (var bufferFileName in _bufferFileNames.Values) System.IO.File.Delete(bufferFileName);
+    }
+
+    [Theory]
+    [InlineData(RollingInterval.Day)]
+    [InlineData(RollingInterval.Hour)]
+    [InlineData(RollingInterval.Infinite)]
+    [InlineData(RollingInterval.Minute)]
+    [InlineData(RollingInterval.Month)]
+    [InlineData(RollingInterval.Year)]
+    public void GetBufferFiles_ReturnsOnlySpecifiedTypeOfRollingFile(RollingInterval rollingInterval)
+    {
+        // Arrange
+        var format = rollingInterval.GetFormat();
+        _bufferFileNames = GenerateFilesUsingFormat(format);
+        var fileSet = new FileSet(_fileNameBase);
+        var bufferFileForInterval = _bufferFileNames[rollingInterval];
+
+        // Act
+        var bufferFiles = fileSet.GetBufferFiles();
+
+        // Assert
+        bufferFiles.Should().BeEquivalentTo(bufferFileForInterval);
+    }
+
+    /// <summary>
+    ///     Generates buffer files for all RollingIntervals and returns dictionary of {rollingInterval, fileName} pairs.
+    /// </summary>
+    /// <param name="format"></param>
+    /// <returns></returns>
+    private Dictionary<RollingInterval, string> GenerateFilesUsingFormat(string format)
+    {
+        var result = new Dictionary<RollingInterval, string>();
+        foreach (var rollingInterval in Enum.GetValues(typeof(RollingInterval)))
+        {
+            var bufferFileName = string.Format(_tempFileFullPathTemplate,
+                string.IsNullOrEmpty(format) ? string.Empty : new DateTime(2000, 1, 1).ToString(format));
+            var lines = new[] {rollingInterval.ToString()};
+            // Important to use UTF8 with BOM if we are starting from 0 position 
+            System.IO.File.WriteAllLines(bufferFileName, lines, new UTF8Encoding(true));
+            result.Add((RollingInterval) rollingInterval, bufferFileName);
+        }
+
+        return result;
+    }
+}

--- a/test/Serilog.Sinks.Elasticsearch.Tests/FileSetTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/FileSetTests.cs
@@ -22,7 +22,10 @@ public class FileSetTests : IDisposable
 
     public void Dispose()
     {
-        foreach (var bufferFileName in _bufferFileNames.Values) System.IO.File.Delete(bufferFileName);
+        foreach (var bufferFileName in _bufferFileNames.Values)
+        {
+            System.IO.File.Delete(bufferFileName);
+        }
     }
 
     [Theory]
@@ -32,12 +35,13 @@ public class FileSetTests : IDisposable
     [InlineData(RollingInterval.Minute)]
     [InlineData(RollingInterval.Month)]
     [InlineData(RollingInterval.Year)]
+    // Ensures that from all presented files FileSet gets only files with specified rolling interval and not the others.  
     public void GetBufferFiles_ReturnsOnlySpecifiedTypeOfRollingFile(RollingInterval rollingInterval)
     {
         // Arrange
         var format = rollingInterval.GetFormat();
         _bufferFileNames = GenerateFilesUsingFormat(format);
-        var fileSet = new FileSet(_fileNameBase);
+        var fileSet = new FileSet(_fileNameBase, rollingInterval);
         var bufferFileForInterval = _bufferFileNames[rollingInterval];
 
         // Act
@@ -48,7 +52,7 @@ public class FileSetTests : IDisposable
     }
 
     /// <summary>
-    ///     Generates buffer files for all RollingIntervals and returns dictionary of {rollingInterval, fileName} pairs.
+    /// Generates buffer files for all RollingIntervals and returns dictionary of {rollingInterval, fileName} pairs.
     /// </summary>
     /// <param name="format"></param>
     /// <returns></returns>

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
@@ -21,6 +21,8 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,6 +33,9 @@
     <None Remove="Templating\template_v5.json" />
     <None Remove="Templating\template_v6.json" />
     <None Remove="Templating\template_v7.json" />
+    <None Include="..\..\assets\Serilog.snk">
+      <Link>Serilog.snk</Link>
+    </None>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**What issue does this PR address?**
Relates to https://github.com/serilog-contrib/serilog-sinks-elasticsearch/issues/410
Add `ElasticsearchSinkOptions.BufferFileRollingInterval` option and support it in `DurableElastisearchSink`.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
- Make support only for intervals like Day, Hour, Minute. As for less frequent intervals we cannot get specific date (specific day) for passing to _getIndexForEvent in `ElasticsearchPayloadReader`.
- Support handling rolling files for different intervals in `ElasticsearchPayloadReader` and `FileSet` by using corresponding formats and search patterns.
- Add tests of changed code - for `ElasticsearchPayloadReader` and `FileSet`
- Add RollingIntervalExtensions.cs (origin: Serilog.Sinks.File) with InternalVisible attribute to be able to test
- Add InternalVisible to FileSet.cs to be able to test it
- Sign tests assembly the same way as Serilog.Sinks.Elasticsearch for InternalVisible to work