### PR TITLE
Do not add null or whitespace lines to payload in ElasticsearchPayloadReader

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchPayloadReader.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchPayloadReader.cs
@@ -82,9 +82,15 @@ namespace Serilog.Sinks.Elasticsearch.Durable
         /// <param name="nextLine"></param>
         protected override void AddToPayLoad(string nextLine)
         {
+            // No need to add empty or whitespace lines to payload
+            if (string.IsNullOrWhiteSpace(nextLine))
+            {
+                return;
+            }
+
             var indexName = _getIndexForEvent(nextLine, _date);
             var action = ElasticsearchSink.CreateElasticAction(
-                opType: _elasticOpType, 
+                opType: _elasticOpType,
                 indexName: indexName, pipelineName: _pipelineName,
                 id: _count + "_" + Guid.NewGuid(),
                 mappingType: _typeName);
@@ -92,6 +98,7 @@ namespace Serilog.Sinks.Elasticsearch.Durable
 
             _payload.Add(actionJson);
             _payload.Add(nextLine);
+
             _count++;
         }
     }

--- a/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchPayloadReaderTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchPayloadReaderTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Serilog.Sinks.Elasticsearch.Durable;
+using Xunit;
+
+namespace Serilog.Sinks.Elasticsearch.Tests;
+
+public class ElasticsearchPayloadReaderTests : IDisposable
+{
+    private readonly string _tempFileFullPath;
+
+    public ElasticsearchPayloadReaderTests()
+    {
+        _tempFileFullPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}-{20000101}.json");
+    }
+
+    public void Dispose()
+    {
+        System.IO.File.Delete(_tempFileFullPath);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData(" ")]
+    public void ReadPayload_SkipsEmptyLines(string emptyLine)
+    {
+        // Arrange
+        var payloadReader = new ElasticsearchPayloadReader("testPipelineName", "TestTypeName", null,
+            (_, _) => "TestIndex", ElasticOpType.Index);
+        var lines = new[]
+        {
+            "line1",
+            emptyLine,
+            "line2"
+        };
+        // Important to use UTF8 with BOM if we are starting from 0 position 
+        System.IO.File.WriteAllLines(_tempFileFullPath, lines, new UTF8Encoding(true));
+
+        // Act
+        var fileSetPosition = new FileSetPosition(0, _tempFileFullPath);
+        var count = 0;
+        var payload = payloadReader.ReadPayload(int.MaxValue, null, ref fileSetPosition, ref count, _tempFileFullPath);
+
+        // Assert
+        payload.Count.Should().Be((lines.Length - 1) * 2);
+        payload[1].Should().Be(lines[0]);
+        payload[3].Should().Be(lines[2]);
+    }
+}


### PR DESCRIPTION
**What issue does this PR address?**
This is done to avoid NullReferenceException in `Elasticsearch.Net.PostData.Write` method in line 204 when we getting bytes from possibly null object `var bytes = enumerator.Current.Utf8Bytes();`

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
These tests fail before that change:
```
using System;
using System.IO;
using System.Text;
using Elasticsearch.Net;
using FluentAssertions;
using Serilog.Sinks.Elasticsearch.Durable;
using Xunit;

namespace Serilog.Sinks.Elasticsearch.Tests;

public class ElasticsearchPayloadReaderTests : IDisposable
{
    private readonly string _tempFileFullPath;

    public ElasticsearchPayloadReaderTests()
    {
        _tempFileFullPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}-{20000101}.json");
    }

    public void Dispose()
    {
        System.IO.File.Delete(_tempFileFullPath);
    }

    [Theory]
    [InlineData("")]
    [InlineData(null)]
    [InlineData(" ")]
    public void ReadPayload_SkipsEmptyLines(string emptyLine)
    {
        // Arrange
        var payloadReader = new ElasticsearchPayloadReader("testPipelineName", "TestTypeName", null,
            (_, _) => "TestIndex", ElasticOpType.Index);
        var lines = new[]
        {
            "line1",
            emptyLine,
            "line2"
        };
        // Important to use UTF8 with BOM if we are starting from 0 position 
        System.IO.File.WriteAllLines(_tempFileFullPath, lines, new UTF8Encoding(true));

        // Act
        var fileSetPosition = new FileSetPosition(0, _tempFileFullPath);
        var count = 0;
        var payload = payloadReader.ReadPayload(int.MaxValue, null, ref fileSetPosition, ref count, _tempFileFullPath);

        // Assert
        // Before the fix, these lines would provide NullReference exception
        var data = PostData.MultiJson(payload);
        data.Write(new MemoryStream(), new ConnectionConfiguration());
    }
}
```