### PR TITLE
Proper handling of TypeName = null from appsettings.json

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
@@ -204,10 +204,7 @@ namespace Serilog
                 options.TemplateName = templateName;
             }
 
-            if (!string.IsNullOrWhiteSpace(typeName))
-            {
-                options.TypeName = typeName;
-            }
+            options.TypeName = !string.IsNullOrWhiteSpace(typeName) ? typeName : null;
 
             options.BatchPostingLimit = batchPostingLimit;
             options.BatchAction = batchAction;


### PR DESCRIPTION
**What issue does this PR address?**
Ability to set TypeName to null via appsettings.json. (Root cause of issue #375 )

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)
Unable to pass most of the unit tests as they seem to need a real cluster to run towards?

**Other information**:
TypeName was already exposed as configurable through appsettings.json but if set to null it is (by Microsofts configuration reader I belive) set to an empty string. This in turns make the already exisiting handling of TypeName in the sink (TypeName is deprecated in Elastic 7.x and unsopported (posts get 400 reply) in Elastic 8.x) not work as intentended. 