### PR TITLE
default typeName is null since _type is removed in ESv7 and unsupported in ESv8+

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -281,7 +281,7 @@ namespace Serilog.Sinks.Elasticsearch
         {
             this.IndexFormat = "logstash-{0:yyyy.MM.dd}";
             this.DeadLetterIndexName = "deadletter-{0:yyyy.MM.dd}";
-            this.TypeName = DefaultTypeName;
+            //this.TypeName = DefaultTypeName;
             this.Period = TimeSpan.FromSeconds(2);
             this.BatchPostingLimit = 50;
             this.SingleEventSizePostingLimit = null;
@@ -300,7 +300,7 @@ namespace Serilog.Sinks.Elasticsearch
         /// The default Elasticsearch type name used for Elasticsearch versions prior to 7.
         /// <para>As of <c>Elasticsearch 7</c> and up <c>_type</c> has been removed.</para>
         /// </summary>
-        public static string DefaultTypeName { get; } = "_doc";
+        public static string DefaultTypeName { get; } = null;
 
         /// <summary>
         /// Instructs the sink to auto detect the running Elasticsearch version.


### PR DESCRIPTION
…in ESv8+

**What issue does this PR address?**

#375 

**Does this PR introduce a breaking change?**

Technically, yes, but since _type is unsupported in ESv8+, then NO. You can't break what is already broken.


**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:

current default is a blocker when trying to configure ES sink from json/yaml, since typename=null or typename="" is just ignored and default typename="_doc" remains in place