### PR TITLE
Read Elasticsearch server version from a root page response

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchVersionManager.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchVersionManager.cs
@@ -56,19 +56,18 @@ namespace Serilog.Sinks.Elasticsearch.Sinks.ElasticSearch
         {
             try
             {
-                var response = _client.Cat.Nodes<StringResponse>(new CatNodesRequestParameters()
-                {
-                    Headers = new[] { "v" }
-                });
+                var response = _client.DoRequest<DynamicResponse>(HttpMethod.GET, "/");
                 if (!response.Success) return null;
 
-                var discoveredVersion = response.Body.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-                    .FirstOrDefault();
+                var discoveredVersion = response.Dictionary["version"]["number"];
 
-                if (discoveredVersion == null)
+                if (!discoveredVersion.HasValue)
                     return null;
 
-                return new Version(discoveredVersion);
+                if (discoveredVersion.Value is not string strVersion)
+                    return null;
+
+                return new Version(strVersion);
 
             }
             catch (Exception ex)

--- a/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchSinkTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchSinkTests.cs
@@ -1,4 +1,5 @@
 ﻿using Elasticsearch.Net;
+using Serilog.Sinks.Elasticsearch.Tests.Stubs;
 using System.Text;
 using Xunit;
 
@@ -18,7 +19,7 @@ namespace Serilog.Sinks.Elasticsearch.Tests
             /* ARRANGE */
             var options = new ElasticsearchSinkOptions
             {
-                Connection = FakeResponse(elasticVersion),
+                Connection = FakeProductCheckResponse(elasticVersion),
                 TypeName = configuredTypeName
             };
 
@@ -41,7 +42,7 @@ namespace Serilog.Sinks.Elasticsearch.Tests
             /* ARRANGE */
             var options = new ElasticsearchSinkOptions
             {
-                Connection = FakeResponse(elasticVersion),
+                Connection = FakeProductCheckResponse(elasticVersion),
                 DetectElasticsearchVersion = false,
                 TypeName = configuredTypeName
             };
@@ -65,7 +66,7 @@ namespace Serilog.Sinks.Elasticsearch.Tests
             /* ARRANGE */
             var options = new ElasticsearchSinkOptions
             {
-                Connection = FakeResponse(elasticVersion),
+                Connection = FakeProductCheckResponse(elasticVersion),
                 DetectElasticsearchVersion = true,
                 TypeName = configuredTypeName
             };
@@ -83,10 +84,10 @@ namespace Serilog.Sinks.Elasticsearch.Tests
             Assert.Equal(expectedTypeName, options.TypeName);
         }
 
-        private static IConnection FakeResponse(string responseText)
+        private static IConnection FakeProductCheckResponse(string responseText)
         {
-            byte[] responseBody = Encoding.UTF8.GetBytes(responseText);
-            return new InMemoryConnection(responseBody, contentType: "text/plain; charset=UTF-8");
+            var productCheckResponse = ConnectionStub.ModifiedProductCheckResponse(responseText);
+            return new InMemoryConnection(productCheckResponse);
         }
     }
 }

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Templating/DiscoverVersionTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Templating/DiscoverVersionTests.cs
@@ -34,7 +34,7 @@ namespace Serilog.Sinks.Elasticsearch.Tests.Templating
         public void TemplatePutToCorrectUrl()
         {
             var uri = _templateGet.Item1;
-            uri.AbsolutePath.Should().Be("/_cat/nodes");
+            uri.AbsolutePath.Should().Be("/");
         }
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
This PR addresses issue #270, Elasticsearch version is now read from the root product page response, which does not require additional privileges.

Unit-test stubs have been adapted to this change as well.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)