### PR TITLE
updated readme about opensearch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Option BufferFileSizeLimitBytes is added The maximum size, in bytes, to which th
 #### Version 9
 
 * Dropped support for 456 and sticking now with NETSTANDARD
+* Dropped support for Opensearch - This package supported writing to Opensearch (without guarantees) up untill the last version, Updated ES packages dropped support for Opensearch
 
 #### Version 7
 


### PR DESCRIPTION
**What issue does this PR address?**
This sink supported (even if unintentionally) Opensearch and was a go-to solution for people using it up until the last version - 
Updated Elasticsearch packages no longer support writing to Opensearch.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
Issue #508 