### PR TITLE
fix: Don't set include_type_name query param for ES v7 template creation call

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
@@ -172,20 +172,17 @@ namespace Serilog.Sinks.Elasticsearch
                     }
                 }
 
-                StringResponse result;                
-                if (_versionManager.EffectiveVersion.Major < 8)
-                { 
-                    result = _client.Indices.PutTemplateForAll<StringResponse>(_templateName, GetTemplatePostData(),
+                var result = _versionManager.EffectiveVersion.Major switch
+                {
+                    < 7 => _client.Indices.PutTemplateForAll<StringResponse>(_templateName, GetTemplatePostData(),
                         new PutIndexTemplateRequestParameters
                         {
                             IncludeTypeName = IncludeTypeName ? true : (bool?)null
-                        });
-                }
-                else
-                {
+                        }),
+                    < 8 => _client.Indices.PutTemplateForAll<StringResponse>(_templateName, GetTemplatePostData()),
                     // Default to version 8 API
-                    result = _client.Indices.PutTemplateV2ForAll<StringResponse>(_templateName, GetTemplatePostData());
-                }
+                    _ => _client.Indices.PutTemplateV2ForAll<StringResponse>(_templateName, GetTemplatePostData()),
+                };
 
                 if (!result.Success)
                 {


### PR DESCRIPTION
**What issue does this PR address?**
#518 

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfils these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)
Sorry, there are no unit tests around the changed code, and making them would require me to mock the `ElasticLowLevelClient` that's being used there, which would require more time then I can spend on this.

**Other information**:
The previous code (treat all <8 version the same) would have been fine if the `TypeName` would have had a valid value, but I noticed that in the constructor of the `ElasticsearchSinkState` class we have some code which sets  its value to `null` for anything higher or equal to ES v7:
```
// Resolve typeName
if (_versionManager.EffectiveVersion.Major < 7)
    _options.TypeName = string.IsNullOrWhiteSpace(_options.TypeName)
        ? ElasticsearchSinkOptions.DefaultTypeName // "logevent"
        : _options.TypeName;
else
    _options.TypeName = null;
```
Therefor you had a scenario for ES v7 where the `TypeName` would be `null`, but the `include_type_name` query parameter would be set to `true`, which wasn't a valid API call for ES v7 